### PR TITLE
Remove deprecated attribute

### DIFF
--- a/Formula/lokalise2.rb
+++ b/Formula/lokalise2.rb
@@ -6,7 +6,6 @@ class Lokalise2 < Formula
   desc "Lokalise CLI v2"
   homepage "https://docs.lokalise.com/cli2"
   version "2.6.8"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Hello,

Homebrew provokes a warning about the deprecated `bottle` attribute and apparently there is no replacement. Also see attached a screenshot from my terminal regarding the deprecation.

<img width="643" alt="Screenshot 2021-11-25 at 00 40 42" src="https://user-images.githubusercontent.com/5719389/143326042-da1e5bf4-4c77-4d72-962a-3e87e6f2448a.png">
